### PR TITLE
RTCIceServer.url deprecated in 2013, use .urls

### DIFF
--- a/script.js
+++ b/script.js
@@ -27,7 +27,7 @@ let room;
 
 const configuration = {
   iceServers: [{
-    url: 'stun:stun.l.google.com:19302'
+    urls: 'stun:stun.l.google.com:19302'
   }]
 };
 // RTCPeerConnection


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/RTCIceServer/url